### PR TITLE
fix: separate citrus spark and orchard bliss buttons

### DIFF
--- a/bundles.html
+++ b/bundles.html
@@ -120,6 +120,12 @@
             onclick="addBundle('citrus_spark')"
             class="cart-action-btn"
             aria-label="Add Citrus Spark bundle to basket"
+          >
+            Add Bundle to Basket
+          </button>
+        </div>
+
+        <div class="bundle-card">
           <h2>Orchard Bliss</h2>
           <div class="bundle-emojis">
             <span role="img" aria-label="Apple">🍏</span>

--- a/shop.js
+++ b/shop.js
@@ -30,7 +30,7 @@ const BUNDLES = {
     name: "Orchard Bliss",
     products: ["apple", "cherry"],
     emoji: "🍏🍒"
-  }
+  },
   citrus_spark: {
     name: "Citrus Spark",
     products: ["lemon", "cherry"],


### PR DESCRIPTION
## Summary
- close the Citrus Spark button markup so Orchard Bliss renders separately
- add missing comma in bundle config to keep both bundles addressable

Fixes #9